### PR TITLE
Remove check

### DIFF
--- a/Superbiz Uploader/Superbiz Uploader.py
+++ b/Superbiz Uploader/Superbiz Uploader.py
@@ -543,7 +543,7 @@ class AudioClass():
         req2 = session.post(
             url="https://auth.roblox.com/"
         )
-        check = session.get('https://api.roblox.com/currency/balance')
+        
         headers = {
 
             'X-CSRF-Token': f'{session.headers["X-CSRF-Token"]}',


### PR DESCRIPTION
Roblox uses new currency api and removed the old hook, so removing the check will stop errors